### PR TITLE
TaskNotifier and TaskNotifier<T>

### DIFF
--- a/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableObject.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableObject.cs
@@ -10,8 +10,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq.Expressions;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 

--- a/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableObject.cs
+++ b/Microsoft.Toolkit.Mvvm/ComponentModel/ObservableObject.cs
@@ -487,7 +487,7 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
                 }
 
                 // Only notify if the property hasn't changed
-                if (ReferenceEquals(newValue, taskNotifier.Task))
+                if (ReferenceEquals(taskNotifier.Task, newValue))
                 {
                     OnPropertyChanged(propertyName);
                 }
@@ -525,8 +525,14 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
             {
             }
 
+            private Task? task;
+
             /// <inheritdoc/>
-            Task? ITaskNotifier<Task>.Task { get; set; }
+            Task? ITaskNotifier<Task>.Task
+            {
+                get => this.task;
+                set => this.task = value;
+            }
 
             /// <summary>
             /// Unwraps the <see cref="Task"/> value stored in the current instance.
@@ -534,7 +540,7 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
             /// <param name="notifier">The input <see cref="TaskNotifier{TTask}"/> instance.</param>
             public static implicit operator Task?(TaskNotifier? notifier)
             {
-                return Unsafe.As<ITaskNotifier<Task>>(notifier)?.Task;
+                return notifier?.task;
             }
         }
 
@@ -551,8 +557,14 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
             {
             }
 
+            private Task<T>? task;
+
             /// <inheritdoc/>
-            Task<T>? ITaskNotifier<Task<T>>.Task { get; set; }
+            Task<T>? ITaskNotifier<Task<T>>.Task
+            {
+                get => this.task;
+                set => this.task = value;
+            }
 
             /// <summary>
             /// Unwraps the <see cref="Task{T}"/> value stored in the current instance.
@@ -560,7 +572,7 @@ namespace Microsoft.Toolkit.Mvvm.ComponentModel
             /// <param name="notifier">The input <see cref="TaskNotifier{TTask}"/> instance.</param>
             public static implicit operator Task<T>?(TaskNotifier<T>? notifier)
             {
-                return Unsafe.As<ITaskNotifier<Task<T>>>(notifier)?.Task;
+                return notifier?.task;
             }
         }
 

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
             this.canExecute = canExecute;
         }
 
-        private Task? executionTask;
+        private TaskAccessor<Task>? executionTask;
 
         /// <inheritdoc/>
         public Task? ExecutionTask
@@ -91,7 +91,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
             get => this.executionTask;
             private set
             {
-                if (SetPropertyAndNotifyOnCompletion(ref this.executionTask, () => this.executionTask, value, _ => OnPropertyChanged(nameof(IsRunning))))
+                if (SetPropertyAndNotifyOnCompletion(ref this.executionTask, value, _ => OnPropertyChanged(nameof(IsRunning))))
                 {
                     OnPropertyChanged(nameof(IsRunning));
                 }

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
             this.canExecute = canExecute;
         }
 
-        private TaskAccessor<Task>? executionTask;
+        private TaskNotifier? executionTask;
 
         /// <inheritdoc/>
         public Task? ExecutionTask

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
             this.canExecute = canExecute;
         }
 
-        private Task? executionTask;
+        private TaskAccessor<Task>? executionTask;
 
         /// <inheritdoc/>
         public Task? ExecutionTask
@@ -91,7 +91,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
             get => this.executionTask;
             private set
             {
-                if (SetPropertyAndNotifyOnCompletion(ref this.executionTask, () => this.executionTask, value, _ => OnPropertyChanged(nameof(IsRunning))))
+                if (SetPropertyAndNotifyOnCompletion(ref this.executionTask, value, _ => OnPropertyChanged(nameof(IsRunning))))
                 {
                     OnPropertyChanged(nameof(IsRunning));
                 }

--- a/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
+++ b/Microsoft.Toolkit.Mvvm/Input/AsyncRelayCommand{T}.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Toolkit.Mvvm.Input
             this.canExecute = canExecute;
         }
 
-        private TaskAccessor<Task>? executionTask;
+        private TaskNotifier? executionTask;
 
         /// <inheritdoc/>
         public Task? ExecutionTask

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableObject.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableObject.cs
@@ -221,12 +221,12 @@ namespace UnitTests.Mvvm
 
         public class SampleModelWithTask<T> : ObservableObject
         {
-            private Task<T> data;
+            private TaskAccessor<Task<T>> data;
 
             public Task<T> Data
             {
                 get => data;
-                set => SetPropertyAndNotifyOnCompletion(ref data, () => data, value);
+                set => SetPropertyAndNotifyOnCompletion(ref data, value);
             }
         }
     }

--- a/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableObject.cs
+++ b/UnitTests/UnitTests.Shared/Mvvm/Test_ObservableObject.cs
@@ -221,7 +221,7 @@ namespace UnitTests.Mvvm
 
         public class SampleModelWithTask<T> : ObservableObject
         {
-            private TaskAccessor<Task<T>> data;
+            private TaskNotifier<T> data;
 
             public Task<T> Data
             {


### PR DESCRIPTION
This PR is an experiment/follow up for https://github.com/windows-toolkit/WindowsCommunityToolkit/pull/3429, which adds the new `TaskNotifier` and `TaskNotifier<T>` to improve the `SetPropertyAndNotifyOnCompletion` methods and make them both more performant, easier to use and working on UWP as well when using the .NET Native compiler.