### PR TITLE
Feature/nint offsetting

### DIFF
--- a/Microsoft.Toolkit.HighPerformance/Buffers/Internals/RawObjectMemoryManager{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Buffers/Internals/RawObjectMemoryManager{T}.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers.Internals
             // reference type or a type containing some references.
             GCHandle handle = GCHandle.Alloc(this.instance, GCHandleType.Pinned);
             ref T r0 = ref this.instance.DangerousGetObjectDataReferenceAt<T>(this.offset);
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)elementIndex);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)elementIndex);
             void* p = Unsafe.AsPointer(ref r1);
 
             return new MemoryHandle(p, handle);

--- a/Microsoft.Toolkit.HighPerformance/Buffers/StringPool.cs
+++ b/Microsoft.Toolkit.HighPerformance/Buffers/StringPool.cs
@@ -536,7 +536,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                      (uint)i < (uint)length;
                      i = entry.NextIndex)
                 {
-                    entry = ref Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)i);
+                    entry = ref Unsafe.Add(ref mapEntriesRef, (nint)(uint)i);
 
                     if (entry.HashCode == hashcode &&
                         entry.Value!.AsSpan().SequenceEqual(span))
@@ -556,7 +556,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
             /// <param name="value">The new <see cref="string"/> instance to store.</param>
             /// <param name="hashcode">The precomputed hashcode for <paramref name="value"/>.</param>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private unsafe void Insert(string value, int hashcode)
+            private void Insert(string value, int hashcode)
             {
                 ref int bucketsRef = ref this.buckets.DangerousGetReference();
                 ref MapEntry mapEntriesRef = ref this.mapEntries.DangerousGetReference();
@@ -571,7 +571,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                     entryIndex = heapEntriesRef.MapIndex;
                     heapIndex = 0;
 
-                    ref MapEntry removedEntry = ref Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)entryIndex);
+                    ref MapEntry removedEntry = ref Unsafe.Add(ref mapEntriesRef, (nint)(uint)entryIndex);
 
                     // The removal logic can be extremely optimized in this case, as we
                     // can retrieve the precomputed hashcode for the target entry by doing
@@ -588,9 +588,9 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                 }
 
                 int bucketIndex = hashcode & (this.buckets.Length - 1);
-                ref int targetBucket = ref Unsafe.Add(ref bucketsRef, (IntPtr)(void*)(uint)bucketIndex);
-                ref MapEntry targetMapEntry = ref Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)entryIndex);
-                ref HeapEntry targetHeapEntry = ref Unsafe.Add(ref heapEntriesRef, (IntPtr)(void*)(uint)heapIndex);
+                ref int targetBucket = ref Unsafe.Add(ref bucketsRef, (nint)(uint)bucketIndex);
+                ref MapEntry targetMapEntry = ref Unsafe.Add(ref mapEntriesRef, (nint)(uint)entryIndex);
+                ref HeapEntry targetHeapEntry = ref Unsafe.Add(ref heapEntriesRef, (nint)(uint)heapIndex);
 
                 // Assign the values in the new map entry
                 targetMapEntry.HashCode = hashcode;
@@ -616,7 +616,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
             /// <param name="mapIndex">The index of the target map node to remove.</param>
             /// <remarks>The input <see cref="string"/> instance needs to already exist in the map.</remarks>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private unsafe void Remove(int hashcode, int mapIndex)
+            private void Remove(int hashcode, int mapIndex)
             {
                 ref MapEntry mapEntriesRef = ref this.mapEntries.DangerousGetReference();
                 int
@@ -628,7 +628,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                 // value we're looking for is guaranteed to be present
                 while (true)
                 {
-                    ref MapEntry candidate = ref Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)entryIndex);
+                    ref MapEntry candidate = ref Unsafe.Add(ref mapEntriesRef, (nint)(uint)entryIndex);
 
                     // Check the current value for a match
                     if (entryIndex == mapIndex)
@@ -636,7 +636,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                         // If this was not the first list node, update the parent as well
                         if (lastIndex != EndOfList)
                         {
-                            ref MapEntry lastEntry = ref Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)lastIndex);
+                            ref MapEntry lastEntry = ref Unsafe.Add(ref mapEntriesRef, (nint)(uint)lastIndex);
 
                             lastEntry.NextIndex = candidate.NextIndex;
                         }
@@ -662,14 +662,14 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
             /// </summary>
             /// <param name="heapIndex">The index of the target heap node to update.</param>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private unsafe void UpdateTimestamp(ref int heapIndex)
+            private void UpdateTimestamp(ref int heapIndex)
             {
                 int
                     currentIndex = heapIndex,
                     count = this.count;
                 ref MapEntry mapEntriesRef = ref this.mapEntries.DangerousGetReference();
                 ref HeapEntry heapEntriesRef = ref this.heapEntries.DangerousGetReference();
-                ref HeapEntry root = ref Unsafe.Add(ref heapEntriesRef, (IntPtr)(void*)(uint)currentIndex);
+                ref HeapEntry root = ref Unsafe.Add(ref heapEntriesRef, (nint)(uint)currentIndex);
                 uint timestamp = this.timestamp;
 
                 // Check if incrementing the current timestamp for the heap node to update
@@ -721,7 +721,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                     // Check and update the left child, if necessary
                     if (left < count)
                     {
-                        ref HeapEntry child = ref Unsafe.Add(ref heapEntriesRef, (IntPtr)(void*)(uint)left);
+                        ref HeapEntry child = ref Unsafe.Add(ref heapEntriesRef, (nint)(uint)left);
 
                         if (child.Timestamp < minimum.Timestamp)
                         {
@@ -733,7 +733,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                     // Same check as above for the right child
                     if (right < count)
                     {
-                        ref HeapEntry child = ref Unsafe.Add(ref heapEntriesRef, (IntPtr)(void*)(uint)right);
+                        ref HeapEntry child = ref Unsafe.Add(ref heapEntriesRef, (nint)(uint)right);
 
                         if (child.Timestamp < minimum.Timestamp)
                         {
@@ -752,8 +752,8 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                     }
 
                     // Update the indices in the respective map entries (accounting for the swap)
-                    Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)root.MapIndex).HeapIndex = targetIndex;
-                    Unsafe.Add(ref mapEntriesRef, (IntPtr)(void*)(uint)minimum.MapIndex).HeapIndex = currentIndex;
+                    Unsafe.Add(ref mapEntriesRef, (nint)(uint)root.MapIndex).HeapIndex = targetIndex;
+                    Unsafe.Add(ref mapEntriesRef, (nint)(uint)minimum.MapIndex).HeapIndex = currentIndex;
 
                     currentIndex = targetIndex;
 
@@ -764,7 +764,7 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
                     minimum = temp;
 
                     // Update the reference to the root node
-                    root = ref Unsafe.Add(ref heapEntriesRef, (IntPtr)(void*)(uint)currentIndex);
+                    root = ref Unsafe.Add(ref heapEntriesRef, (nint)(uint)currentIndex);
                 }
 
                 Fallback:
@@ -787,14 +787,14 @@ namespace Microsoft.Toolkit.HighPerformance.Buffers
             /// a given number of nodes, those are all contiguous from the start of the array.
             /// </summary>
             [MethodImpl(MethodImplOptions.NoInlining)]
-            private unsafe void UpdateAllTimestamps()
+            private void UpdateAllTimestamps()
             {
                 int count = this.count;
                 ref HeapEntry heapEntriesRef = ref this.heapEntries.DangerousGetReference();
 
                 for (int i = 0; i < count; i++)
                 {
-                    Unsafe.Add(ref heapEntriesRef, (IntPtr)(void*)(uint)i).Timestamp = (uint)i;
+                    Unsafe.Add(ref heapEntriesRef, (nint)(uint)i).Timestamp = (uint)i;
                 }
             }
         }

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlyRefEnumerable{T}.cs
@@ -115,13 +115,10 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
                 return ref this.span.DangerousGetReferenceAt(this.position);
 #else
-                unsafe
-                {
-                    ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-                    ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)this.position);
+                ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
+                ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.position);
 
-                    return ref ri;
-                }
+                return ref ri;
 #endif
             }
         }
@@ -133,7 +130,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="destination" /> is shorter than the source <see cref="RefEnumerable{T}"/> instance.
         /// </exception>
-        public readonly unsafe void CopyTo(Span<T> destination)
+        public readonly void CopyTo(Span<T> destination)
         {
 #if SPAN_RUNTIME_SUPPORT
             if (this.step == 1)
@@ -158,7 +155,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
             for (int i = 0, j = 0; i < length; i += this.step, j++)
             {
-                Unsafe.Add(ref destinationRef, (IntPtr)(void*)(uint)j) = Unsafe.Add(ref sourceRef, (IntPtr)(void*)(uint)i);
+                Unsafe.Add(ref destinationRef, (nint)(uint)j) = Unsafe.Add(ref sourceRef, (nint)(uint)i);
             }
         }
 
@@ -187,7 +184,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
         /// <inheritdoc cref="RefEnumerable{T}.ToArray"/>
         [Pure]
-        public readonly unsafe T[] ToArray()
+        public readonly T[] ToArray()
         {
 #if SPAN_RUNTIME_SUPPORT
             // Fast path for contiguous items
@@ -218,7 +215,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
             for (int i = 0, j = 0; i < length; i += this.step, j++)
             {
-                Unsafe.Add(ref destinationRef, (IntPtr)(void*)(uint)j) = Unsafe.Add(ref sourceRef, (IntPtr)(void*)(uint)i);
+                Unsafe.Add(ref destinationRef, (nint)(uint)j) = Unsafe.Add(ref sourceRef, (nint)(uint)i);
             }
 
             return array;

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlySpanEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/ReadOnlySpanEnumerable{T}.cs
@@ -66,14 +66,11 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             get
             {
 #if SPAN_RUNTIME_SUPPORT
-                unsafe
-                {
-                    ref T r0 = ref MemoryMarshal.GetReference(this.span);
-                    ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)this.index);
+                ref T r0 = ref MemoryMarshal.GetReference(this.span);
+                ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.index);
 
-                    // See comment in SpanEnumerable<T> about this
-                    return new Item(ref ri, this.index);
-                }
+                // See comment in SpanEnumerable<T> about this
+                return new Item(ref ri, this.index);
 #else
                 return new Item(this.span, this.index);
 #endif
@@ -132,13 +129,10 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
                     return ref MemoryMarshal.GetReference(this.span);
 #else
-                    unsafe
-                    {
-                        ref T r0 = ref MemoryMarshal.GetReference(this.span);
-                        ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)this.index);
+                    ref T r0 = ref MemoryMarshal.GetReference(this.span);
+                    ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.index);
 
-                        return ref ri;
-                    }
+                    return ref ri;
 #endif
                 }
             }

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
@@ -67,9 +67,9 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal RefEnumerable(ref T reference, int length, int step)
         {
-            this.span = MemoryMarshal.CreateSpan(ref reference, length * step);
+            this.span = MemoryMarshal.CreateSpan(ref reference, length);
             this.step = step;
-            this.position = -step;
+            this.position = -1;
         }
 #else
         /// <summary>
@@ -84,9 +84,9 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         {
             this.instance = instance;
             this.offset = offset;
-            this.length = length * step;
+            this.length = length;
             this.step = step;
-            this.position = -step;
+            this.position = -1;
         }
 #endif
 
@@ -100,9 +100,9 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         public bool MoveNext()
         {
 #if SPAN_RUNTIME_SUPPORT
-            return (this.position += this.step) < this.span.Length;
+            return ++this.position < this.span.Length;
 #else
-            return (this.position += this.step) < this.length;
+            return ++this.position < this.length;
 #endif
         }
 
@@ -113,13 +113,21 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             get
             {
 #if SPAN_RUNTIME_SUPPORT
-                return ref this.span.DangerousGetReferenceAt(this.position);
+                ref T r0 = ref this.span.DangerousGetReference();
 #else
                 ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-                ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.position);
+#endif
+
+                // Here we just offset by shifting down as if we were traversing a 2D array with a
+                // a single column, with the width of each row represented by the step, the height
+                // represented by the current position, and with only the first element of each row
+                // being inspected. We can perform all the indexing operations in this type as nint,
+                // as the maximum offset is guaranteed never to exceed the maximum value, since on
+                // 32 bit architectures it's not possible to allocate that much memory anyway.
+                nint offset = (nint)(uint)this.position * (nint)(uint)this.step;
+                ref T ri = ref Unsafe.Add(ref r0, offset);
 
                 return ref ri;
-#endif
             }
         }
 
@@ -143,10 +151,13 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
             int length = this.length;
 #endif
+            nint
+                step = (nint)(uint)this.step,
+                offset = 0;
 
-            for (int i = 0; i < length; i += this.step)
+            for (int i = length; i >= 0; i--, offset += step)
             {
-                Unsafe.Add(ref r0, (nint)(uint)i) = default!;
+                Unsafe.Add(ref r0, offset) = default!;
             }
         }
 
@@ -173,16 +184,19 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             ref T sourceRef = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
             int length = this.length;
 #endif
-            if ((uint)destination.Length < (uint)(length / this.step))
+            if ((uint)destination.Length < (uint)length)
             {
                 ThrowArgumentExceptionForDestinationTooShort();
             }
 
             ref T destinationRef = ref destination.DangerousGetReference();
+            nint
+                step = (nint)(uint)this.step,
+                offset = 0;
 
-            for (int i = 0, j = 0; i < length; i += this.step, j++)
+            for (int i = 0; i < length; i++, offset += step)
             {
-                Unsafe.Add(ref destinationRef, (nint)(uint)j) = Unsafe.Add(ref sourceRef, (nint)(uint)i);
+                Unsafe.Add(ref destinationRef, i) = Unsafe.Add(ref sourceRef, offset);
             }
         }
 
@@ -234,9 +248,13 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             int length = this.length;
 #endif
 
-            for (int i = 0; i < length; i += this.step)
+            nint
+                step = (nint)(uint)this.step,
+                offset = 0;
+
+            for (int i = length; i >= 0; i--, offset += step)
             {
-                Unsafe.Add(ref r0, (nint)(uint)i) = value;
+                Unsafe.Add(ref r0, offset) = value;
             }
         }
 
@@ -254,11 +272,6 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         public readonly T[] ToArray()
         {
 #if SPAN_RUNTIME_SUPPORT
-            if (this.step == 1)
-            {
-                return this.span.ToArray();
-            }
-
             int length = this.span.Length;
 #else
             int length = this.length;
@@ -270,19 +283,9 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
                 return Array.Empty<T>();
             }
 
-#if SPAN_RUNTIME_SUPPORT
-            ref T sourceRef = ref this.span.DangerousGetReference();
-#else
-            ref T sourceRef = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-#endif
+            T[] array = new T[length];
 
-            T[] array = new T[length / this.step];
-            ref T destinationRef = ref array.DangerousGetReference();
-
-            for (int i = 0, j = 0; i < length; i += this.step, j++)
-            {
-                Unsafe.Add(ref destinationRef, (nint)(uint)j) = Unsafe.Add(ref sourceRef, (nint)(uint)i);
-            }
+            CopyTo(array);
 
             return array;
         }

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/RefEnumerable{T}.cs
@@ -115,13 +115,10 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
                 return ref this.span.DangerousGetReferenceAt(this.position);
 #else
-                unsafe
-                {
-                    ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
-                    ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)this.position);
+                ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
+                ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.position);
 
-                    return ref ri;
-                }
+                return ref ri;
 #endif
             }
         }
@@ -129,7 +126,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// <summary>
         /// Clears the contents of the current <see cref="RefEnumerable{T}"/> instance.
         /// </summary>
-        public readonly unsafe void Clear()
+        public readonly void Clear()
         {
 #if SPAN_RUNTIME_SUPPORT
             // Fast path for contiguous items
@@ -149,7 +146,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
             for (int i = 0; i < length; i += this.step)
             {
-                Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i) = default!;
+                Unsafe.Add(ref r0, (nint)(uint)i) = default!;
             }
         }
 
@@ -160,7 +157,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="destination" /> is shorter than the source <see cref="RefEnumerable{T}"/> instance.
         /// </exception>
-        public readonly unsafe void CopyTo(Span<T> destination)
+        public readonly void CopyTo(Span<T> destination)
         {
 #if SPAN_RUNTIME_SUPPORT
             if (this.step == 1)
@@ -185,7 +182,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
             for (int i = 0, j = 0; i < length; i += this.step, j++)
             {
-                Unsafe.Add(ref destinationRef, (IntPtr)(void*)(uint)j) = Unsafe.Add(ref sourceRef, (IntPtr)(void*)(uint)i);
+                Unsafe.Add(ref destinationRef, (nint)(uint)j) = Unsafe.Add(ref sourceRef, (nint)(uint)i);
             }
         }
 
@@ -220,7 +217,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// This method will always return the whole sequence from the start, ignoring the
         /// current position in case the sequence has already been enumerated in part.
         /// </remarks>
-        public readonly unsafe void Fill(T value)
+        public readonly void Fill(T value)
         {
 #if SPAN_RUNTIME_SUPPORT
             if (this.step == 1)
@@ -239,7 +236,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
             for (int i = 0; i < length; i += this.step)
             {
-                Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i) = value;
+                Unsafe.Add(ref r0, (nint)(uint)i) = value;
             }
         }
 
@@ -254,7 +251,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
         /// ignoring the current position in case the sequence has already been enumerated in part.
         /// </remarks>
         [Pure]
-        public readonly unsafe T[] ToArray()
+        public readonly T[] ToArray()
         {
 #if SPAN_RUNTIME_SUPPORT
             if (this.step == 1)
@@ -284,7 +281,7 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 
             for (int i = 0, j = 0; i < length; i += this.step, j++)
             {
-                Unsafe.Add(ref destinationRef, (IntPtr)(void*)(uint)j) = Unsafe.Add(ref sourceRef, (IntPtr)(void*)(uint)i);
+                Unsafe.Add(ref destinationRef, (nint)(uint)j) = Unsafe.Add(ref sourceRef, (nint)(uint)i);
             }
 
             return array;

--- a/Microsoft.Toolkit.HighPerformance/Enumerables/SpanEnumerable{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Enumerables/SpanEnumerable{T}.cs
@@ -66,19 +66,16 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
             get
             {
 #if SPAN_RUNTIME_SUPPORT
-                unsafe
-                {
-                    ref T r0 = ref MemoryMarshal.GetReference(this.span);
-                    ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)this.index);
+                ref T r0 = ref MemoryMarshal.GetReference(this.span);
+                ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.index);
 
-                    // On .NET Standard 2.1 and .NET Core (or on any target that offers runtime
-                    // support for the Span<T> types), we can save 4 bytes by piggybacking the
-                    // current index in the length of the wrapped span. We're going to use the
-                    // first item as the target reference, and the length as a host for the
-                    // current original offset. This is not possible on eg. .NET Standard 2.0,
-                    // as we lack the API to create Span<T>-s from arbitrary references.
-                    return new Item(ref ri, this.index);
-                }
+                // On .NET Standard 2.1 and .NET Core (or on any target that offers runtime
+                // support for the Span<T> types), we can save 4 bytes by piggybacking the
+                // current index in the length of the wrapped span. We're going to use the
+                // first item as the target reference, and the length as a host for the
+                // current original offset. This is not possible on eg. .NET Standard 2.0,
+                // as we lack the API to create Span<T>-s from arbitrary references.
+                return new Item(ref ri, this.index);
 #else
                 return new Item(this.span, this.index);
 #endif
@@ -137,13 +134,10 @@ namespace Microsoft.Toolkit.HighPerformance.Enumerables
 #if SPAN_RUNTIME_SUPPORT
                     return ref MemoryMarshal.GetReference(this.span);
 #else
-                    unsafe
-                    {
-                        ref T r0 = ref MemoryMarshal.GetReference(this.span);
-                        ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)this.index);
+                    ref T r0 = ref MemoryMarshal.GetReference(this.span);
+                    ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)this.index);
 
-                        return ref ri;
-                    }
+                    return ref ri;
 #endif
                 }
             }

--- a/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.1D.cs
@@ -54,18 +54,18 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref T DangerousGetReferenceAt<T>(this T[] array, int i)
+        public static ref T DangerousGetReferenceAt<T>(this T[] array, int i)
         {
 #if NETCORE_RUNTIME
             var arrayData = Unsafe.As<RawArrayData>(array);
             ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 
             return ref ri;
 #else
             IntPtr offset = RuntimeHelpers.GetArrayDataByteOffset<T>();
             ref T r0 = ref array.DangerousGetObjectDataReferenceAt<T>(offset);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 
             return ref ri;
 #endif
@@ -102,11 +102,11 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="array"/>.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int Count<T>(this T[] array, T value)
+        public static int Count<T>(this T[] array, T value)
             where T : IEquatable<T>
         {
             ref T r0 = ref array.DangerousGetReference();
-            IntPtr length = (IntPtr)(void*)(uint)array.Length;
+            nint length = (nint)(uint)array.Length;
 
             return SpanHelper.Count(ref r0, length, value);
         }
@@ -173,11 +173,11 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int GetDjb2HashCode<T>(this T[] array)
+        public static int GetDjb2HashCode<T>(this T[] array)
             where T : notnull
         {
             ref T r0 = ref array.DangerousGetReference();
-            IntPtr length = (IntPtr)(void*)(uint)array.Length;
+            nint length = (nint)(uint)array.Length;
 
             return SpanHelper.GetDjb2HashCode(ref r0, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.2D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.2D.cs
@@ -62,13 +62,13 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// </remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref T DangerousGetReferenceAt<T>(this T[,] array, int i, int j)
+        public static ref T DangerousGetReferenceAt<T>(this T[,] array, int i, int j)
         {
 #if NETCORE_RUNTIME
             var arrayData = Unsafe.As<RawArray2DData>(array);
             int offset = (i * arrayData.Width) + j;
             ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)offset);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)offset);
 
             return ref ri;
 #else
@@ -77,7 +77,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
                 index = (i * width) + j;
             IntPtr offset = RuntimeHelpers.GetArray2DDataByteOffset<T>();
             ref T r0 = ref array.DangerousGetObjectDataReferenceAt<T>(offset);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)index);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)index);
 
             return ref ri;
 #endif
@@ -396,7 +396,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             where T : IEquatable<T>
         {
             ref T r0 = ref array.DangerousGetReference();
-            IntPtr length = (IntPtr)(void*)(uint)array.Length;
+            nint length = (nint)(uint)array.Length;
 
             return SpanHelper.Count(ref r0, length, value);
         }
@@ -415,7 +415,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             where T : notnull
         {
             ref T r0 = ref array.DangerousGetReference();
-            IntPtr length = (IntPtr)(void*)(uint)array.Length;
+            nint length = (nint)(uint)array.Length;
 
             return SpanHelper.GetDjb2HashCode(ref r0, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
@@ -62,13 +62,13 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// </remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref T DangerousGetReferenceAt<T>(this T[,,] array, int i, int j, int k)
+        public static ref T DangerousGetReferenceAt<T>(this T[,,] array, int i, int j, int k)
         {
 #if NETCORE_RUNTIME
             var arrayData = Unsafe.As<RawArray3DData>(array);
             int offset = (i * arrayData.Height * arrayData.Width) + (j * arrayData.Width) + k;
             ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)offset);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)offset);
 
             return ref ri;
 #else
@@ -78,7 +78,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
                 index = (i * height * width) + (j * width) + k;
             IntPtr offset = RuntimeHelpers.GetArray3DDataByteOffset<T>();
             ref T r0 = ref array.DangerousGetObjectDataReferenceAt<T>(offset);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)index);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)index);
 
             return ref ri;
 #endif

--- a/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/ArrayExtensions.3D.cs
@@ -11,9 +11,7 @@ using Microsoft.Toolkit.HighPerformance.Buffers.Internals;
 #endif
 using Microsoft.Toolkit.HighPerformance.Helpers.Internals;
 using Microsoft.Toolkit.HighPerformance.Memory;
-#if !NETCORE_RUNTIME || SPAN_RUNTIME_SUPPORT
 using RuntimeHelpers = Microsoft.Toolkit.HighPerformance.Helpers.Internals.RuntimeHelpers;
-#endif
 
 namespace Microsoft.Toolkit.HighPerformance.Extensions
 {
@@ -66,19 +64,23 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         {
 #if NETCORE_RUNTIME
             var arrayData = Unsafe.As<RawArray3DData>(array);
-            int offset = (i * arrayData.Height * arrayData.Width) + (j * arrayData.Width) + k;
+            nint offset =
+                ((nint)(uint)i * (nint)(uint)arrayData.Height * (nint)(uint)arrayData.Width) +
+                ((nint)(uint)j * (nint)(uint)arrayData.Width) + (nint)(uint)k;
             ref T r0 = ref Unsafe.As<byte, T>(ref arrayData.Data);
-            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)offset);
+            ref T ri = ref Unsafe.Add(ref r0, offset);
 
             return ref ri;
 #else
             int
                 height = array.GetLength(1),
-                width = array.GetLength(2),
-                index = (i * height * width) + (j * width) + k;
+                width = array.GetLength(2);
+            nint index =
+                ((nint)(uint)i * (nint)(uint)height * (nint)(uint)width) +
+                ((nint)(uint)j * (nint)(uint)width) + (nint)(uint)k;
             IntPtr offset = RuntimeHelpers.GetArray3DDataByteOffset<T>();
             ref T r0 = ref array.DangerousGetObjectDataReferenceAt<T>(offset);
-            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)index);
+            ref T ri = ref Unsafe.Add(ref r0, index);
 
             return ref ri;
 #endif
@@ -126,7 +128,10 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
                 ThrowArrayTypeMismatchException();
             }
 
-            return new RawObjectMemoryManager<T>(array, RuntimeHelpers.GetArray3DDataByteOffset<T>(), array.Length).Memory;
+            IntPtr offset = RuntimeHelpers.GetArray3DDataByteOffset<T>();
+            int length = array.Length;
+
+            return new RawObjectMemoryManager<T>(array, offset, length).Memory;
         }
 
         /// <summary>
@@ -179,7 +184,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             }
 
             ref T r0 = ref array.DangerousGetReferenceAt(depth, 0, 0);
-            int length = array.GetLength(1) * array.GetLength(2);
+            int length = checked(array.GetLength(1) * array.GetLength(2));
 
             return MemoryMarshal.CreateSpan(ref r0, length);
         }
@@ -209,7 +214,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
 
             ref T r0 = ref array.DangerousGetReferenceAt(depth, 0, 0);
             IntPtr offset = array.DangerousGetObjectDataByteOffset(ref r0);
-            int length = array.GetLength(1) * array.GetLength(2);
+            int length = checked(array.GetLength(1) * array.GetLength(2));
 
             return new RawObjectMemoryManager<T>(array, offset, length).Memory;
         }
@@ -264,7 +269,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             where T : IEquatable<T>
         {
             ref T r0 = ref array.DangerousGetReference();
-            IntPtr length = (IntPtr)array.Length;
+            nint length = RuntimeHelpers.GetArrayNativeLength(array);
 
             return SpanHelper.Count(ref r0, length, value);
         }
@@ -283,7 +288,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             where T : notnull
         {
             ref T r0 = ref array.DangerousGetReference();
-            IntPtr length = (IntPtr)array.Length;
+            nint length = RuntimeHelpers.GetArrayNativeLength(array);
 
             return SpanHelper.GetDjb2HashCode(ref r0, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref T DangerousGetReferenceAt<T>(this ReadOnlySpan<T> span, int i)
+        public static ref T DangerousGetReferenceAt<T>(this ReadOnlySpan<T> span, int i)
         {
             // Here we assume the input index will never be negative, so we do an unsafe cast to
             // force the JIT to skip the sign extension when going from int to native int.
@@ -74,7 +74,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             // JIT compiler (see https://github.com/dotnet/runtime/issues/38794), but doing this here
             // still ensures the optimal codegen even on existing runtimes (eg. .NET Core 2.1 and 3.1).
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 
             return ref ri;
         }
@@ -118,7 +118,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// </returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref readonly T DangerousGetLookupReferenceAt<T>(this ReadOnlySpan<T> span, int i)
+        public static ref readonly T DangerousGetLookupReferenceAt<T>(this ReadOnlySpan<T> span, int i)
         {
             // Check whether the input is in range by first casting both
             // operands to uint and then comparing them, as this allows
@@ -142,7 +142,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
                 mask = ~negativeFlag,
                 offset = (uint)i & mask;
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)offset);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)offset);
 
             return ref r1;
         }
@@ -242,11 +242,11 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="span"/>.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int Count<T>(this ReadOnlySpan<T> span, T value)
+        public static int Count<T>(this ReadOnlySpan<T> span, T value)
             where T : IEquatable<T>
         {
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            IntPtr length = (IntPtr)(void*)(uint)span.Length;
+            nint length = (nint)(uint)span.Length;
 
             return SpanHelper.Count(ref r0, length, value);
         }
@@ -368,11 +368,11 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int GetDjb2HashCode<T>(this ReadOnlySpan<T> span)
+        public static int GetDjb2HashCode<T>(this ReadOnlySpan<T> span)
             where T : notnull
         {
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            IntPtr length = (IntPtr)(void*)(uint)span.Length;
+            nint length = (nint)(uint)span.Length;
 
             return SpanHelper.GetDjb2HashCode(ref r0, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Extensions/SpanExtensions.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/SpanExtensions.cs
@@ -49,6 +49,24 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
             return ref ri;
         }
 
+        /// <summary>
+        /// Returns a reference to an element at a specified index within a given <see cref="Span{T}"/>, with no bounds checks.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the input <see cref="Span{T}"/> instance.</typeparam>
+        /// <param name="span">The input <see cref="Span{T}"/> instance.</param>
+        /// <param name="i">The index of the element to retrieve within <paramref name="span"/>.</param>
+        /// <returns>A reference to the element within <paramref name="span"/> at the index specified by <paramref name="i"/>.</returns>
+        /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ref T DangerousGetReferenceAt<T>(this Span<T> span, nint i)
+        {
+            ref T r0 = ref MemoryMarshal.GetReference(span);
+            ref T ri = ref Unsafe.Add(ref r0, i);
+
+            return ref ri;
+        }
+
 #if SPAN_RUNTIME_SUPPORT
         /// <summary>
         /// Returns a <see cref="Span2D{T}"/> instance wrapping the underlying data for the given <see cref="Span{T}"/> instance.

--- a/Microsoft.Toolkit.HighPerformance/Extensions/SpanExtensions.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/SpanExtensions.cs
@@ -41,10 +41,10 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref T DangerousGetReferenceAt<T>(this Span<T> span, int i)
+        public static ref T DangerousGetReferenceAt<T>(this Span<T> span, int i)
         {
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            ref T ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i);
+            ref T ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 
             return ref ri;
         }
@@ -187,11 +187,11 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <returns>The number of occurrences of <paramref name="value"/> in <paramref name="span"/>.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int Count<T>(this Span<T> span, T value)
+        public static int Count<T>(this Span<T> span, T value)
             where T : IEquatable<T>
         {
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            IntPtr length = (IntPtr)(void*)(uint)span.Length;
+            nint length = (nint)(uint)span.Length;
 
             return SpanHelper.Count(ref r0, length, value);
         }
@@ -258,11 +258,11 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>The Djb2 hash is fully deterministic and with no random components.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int GetDjb2HashCode<T>(this Span<T> span)
+        public static int GetDjb2HashCode<T>(this Span<T> span)
             where T : notnull
         {
             ref T r0 = ref MemoryMarshal.GetReference(span);
-            IntPtr length = (IntPtr)(void*)(uint)span.Length;
+            nint length = (nint)(uint)span.Length;
 
             return SpanHelper.GetDjb2HashCode(ref r0, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Extensions/StringExtensions.cs
+++ b/Microsoft.Toolkit.HighPerformance/Extensions/StringExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <remarks>This method doesn't do any bounds checks, therefore it is responsibility of the caller to ensure the <paramref name="i"/> parameter is valid.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ref char DangerousGetReferenceAt(this string text, int i)
+        public static ref char DangerousGetReferenceAt(this string text, int i)
         {
 #if NETCOREAPP3_1
             ref char r0 = ref Unsafe.AsRef(text.GetPinnableReference());
@@ -57,7 +57,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
 #else
             ref char r0 = ref MemoryMarshal.GetReference(text.AsSpan());
 #endif
-            ref char ri = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)i);
+            ref char ri = ref Unsafe.Add(ref r0, (nint)(uint)i);
 
             return ref ri;
         }
@@ -91,10 +91,10 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         /// <returns>The number of occurrences of <paramref name="c"/> in <paramref name="text"/>.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int Count(this string text, char c)
+        public static int Count(this string text, char c)
         {
             ref char r0 = ref text.DangerousGetReference();
-            IntPtr length = (IntPtr)(void*)(uint)text.Length;
+            nint length = (nint)(uint)text.Length;
 
             return SpanHelper.Count(ref r0, length, c);
         }
@@ -160,7 +160,7 @@ namespace Microsoft.Toolkit.HighPerformance.Extensions
         public static unsafe int GetDjb2HashCode(this string text)
         {
             ref char r0 = ref text.DangerousGetReference();
-            IntPtr length = (IntPtr)(void*)(uint)text.Length;
+            nint length = (nint)(uint)text.Length;
 
             return SpanHelper.GetDjb2HashCode(ref r0, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Helpers/HashCode{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/HashCode{T}.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
         /// <remarks>The returned hash code is not processed through <see cref="HashCode"/> APIs.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe int CombineValues(ReadOnlySpan<T> span)
+        internal static int CombineValues(ReadOnlySpan<T> span)
         {
             ref T r0 = ref MemoryMarshal.GetReference(span);
 
@@ -64,7 +64,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             // compiler, so this branch will never actually be executed by the code.
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                return SpanHelper.GetDjb2HashCode(ref r0, (IntPtr)(void*)(uint)span.Length);
+                return SpanHelper.GetDjb2HashCode(ref r0, (nint)(uint)span.Length);
             }
 
             // Get the info for the target memory area to process.
@@ -75,7 +75,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             // process. In that case it will just compute the byte size as a 32 bit
             // multiplication with overflow, which is guaranteed never to happen anyway.
             ref byte rb = ref Unsafe.As<T, byte>(ref r0);
-            IntPtr length = (IntPtr)(void*)((uint)span.Length * (uint)Unsafe.SizeOf<T>());
+            nint length = (nint)((uint)span.Length * (uint)Unsafe.SizeOf<T>());
 
             return SpanHelper.GetDjb2LikeByteHash(ref rb, length);
         }

--- a/Microsoft.Toolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/Internals/RuntimeHelpers.cs
@@ -23,6 +23,25 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers.Internals
     internal static class RuntimeHelpers
     {
         /// <summary>
+        /// Gets the length of a given array as a native integer.
+        /// </summary>
+        /// <param name="array">The input <see cref="Array"/> instance.</param>
+        /// <returns>The total length of <paramref name="array"/> as a native integer.</returns>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static nint GetArrayNativeLength(Array array)
+        {
+#if NETSTANDARD1_4
+            // .NET Standard 1.4 doesn't include the API to get the long length, so
+            // we just cast the length and throw in case the array is larger than
+            // int.MaxValue. There's not much we can do in this specific case.
+            return (nint)(uint)array.Length;
+#else
+            return (nint)array.LongLength;
+#endif
+        }
+
+        /// <summary>
         /// Gets the byte offset to the first <typeparamref name="T"/> element in a SZ array.
         /// </summary>
         /// <typeparam name="T">The type of values in the array.</typeparam>

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             /// Processes the batch of actions at a specified index
             /// </summary>
             /// <param name="i">The index of the batch to process</param>
-            public unsafe void Invoke(int i)
+            public void Invoke(int i)
             {
                 int
                     low = i * this.batchSize,
@@ -146,7 +146,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
 
                 for (int j = low; j < end; j++)
                 {
-                    ref TItem rj = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)j);
+                    ref TItem rj = ref Unsafe.Add(ref r0, (nint)(uint)j);
 
                     Unsafe.AsRef(this.action).Invoke(rj);
                 }

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
@@ -84,11 +84,12 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
                 return;
             }
 
-            int
+            nint
                 maxBatches = 1 + ((memory.Length - 1) / minimumActionsPerThread),
-                clipBatches = Math.Min(maxBatches, memory.Height),
+                clipBatches = maxBatches <= memory.Height ? maxBatches : memory.Height;
+            int
                 cores = Environment.ProcessorCount,
-                numBatches = Math.Min(clipBatches, cores),
+                numBatches = (int)(clipBatches <= cores ? clipBatches : cores),
                 batchHeight = 1 + ((memory.Height - 1) / numBatches);
 
             var actionInvoker = new InActionInvokerWithReadOnlyMemory2D<TItem, TAction>(batchHeight, memory, action);
@@ -134,10 +135,10 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             /// <param name="i">The index of the batch to process</param>
             public void Invoke(int i)
             {
+                int lowY = i * this.batchHeight;
+                nint highY = lowY + this.batchHeight;
                 int
-                    lowY = i * this.batchHeight,
-                    highY = lowY + this.batchHeight,
-                    stopY = Math.Min(highY, this.memory.Height),
+                    stopY = (int)(highY <= this.memory.Height ? highY : this.memory.Height),
                     width = this.memory.Width;
 
                 ReadOnlySpan2D<TItem> span = this.memory.Span;

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             /// Processes the batch of actions at a specified index
             /// </summary>
             /// <param name="i">The index of the batch to process</param>
-            public unsafe void Invoke(int i)
+            public void Invoke(int i)
             {
                 int
                     lowY = i * this.batchHeight,
@@ -148,7 +148,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
 
                     for (int x = 0; x < width; x++)
                     {
-                        ref TItem ryx = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)x);
+                        ref TItem ryx = ref Unsafe.Add(ref r0, (nint)(uint)x);
 
                         Unsafe.AsRef(this.action).Invoke(ryx);
                     }

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IInAction2D.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             }
 
             int
-                maxBatches = 1 + ((memory.Size - 1) / minimumActionsPerThread),
+                maxBatches = 1 + ((memory.Length - 1) / minimumActionsPerThread),
                 clipBatches = Math.Min(maxBatches, memory.Height),
                 cores = Environment.ProcessorCount,
                 numBatches = Math.Min(clipBatches, cores),

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             /// Processes the batch of actions at a specified index
             /// </summary>
             /// <param name="i">The index of the batch to process</param>
-            public unsafe void Invoke(int i)
+            public void Invoke(int i)
             {
                 int
                     low = i * this.batchSize,
@@ -146,7 +146,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
 
                 for (int j = low; j < end; j++)
                 {
-                    ref TItem rj = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)j);
+                    ref TItem rj = ref Unsafe.Add(ref r0, (nint)(uint)j);
 
                     Unsafe.AsRef(this.action).Invoke(ref rj);
                 }

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction2D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction2D.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             /// Processes the batch of actions at a specified index
             /// </summary>
             /// <param name="i">The index of the batch to process</param>
-            public unsafe void Invoke(int i)
+            public void Invoke(int i)
             {
                 int
                     lowY = i * this.batchHeight,
@@ -148,7 +148,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
 
                     for (int x = 0; x < width; x++)
                     {
-                        ref TItem ryx = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)x);
+                        ref TItem ryx = ref Unsafe.Add(ref r0, (nint)(uint)x);
 
                         Unsafe.AsRef(this.action).Invoke(ref ryx);
                     }

--- a/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction2D.cs
+++ b/Microsoft.Toolkit.HighPerformance/Helpers/ParallelHelper.ForEach.IRefAction2D.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Toolkit.HighPerformance.Helpers
             }
 
             int
-                maxBatches = 1 + ((memory.Size - 1) / minimumActionsPerThread),
+                maxBatches = 1 + ((memory.Length - 1) / minimumActionsPerThread),
                 clipBatches = Math.Min(maxBatches, memory.Height),
                 cores = Environment.ProcessorCount,
                 numBatches = Math.Min(clipBatches, cores),

--- a/Microsoft.Toolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.CompilerServices;
+using static System.Math;
+
+namespace Microsoft.Toolkit.HighPerformance.Memory.Internals
+{
+    /// <summary>
+    /// A helper to validate arithmetic operations for <see cref="Memory2D{T}"/> and <see cref="Span2D{T}"/>.
+    /// </summary>
+    internal static class OverflowHelper
+    {
+        /// <summary>
+        /// Ensures that the input parameters will not exceed the maximum native int value when indexing.
+        /// </summary>
+        /// <param name="height">The height of the 2D memory area to map.</param>
+        /// <param name="width">The width of the 2D memory area to map.</param>
+        /// <param name="pitch">The pitch of the 2D memory area to map (the distance between each row).</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EnsureIsInNativeIntRange(int height, int width, int pitch)
+        {
+            // As per the layout used in the Memory2D<T> and Span2D<T> types, we have the
+            // following memory representation with respect to height, width and pitch:
+            //
+            //               _________width_________  ________...
+            //              /                       \/
+            // | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |_
+            // | -- | -- | XX | XX | XX | XX | XX | XX | -- | -- | |
+            // | -- | -- | XX | XX | XX | XX | XX | XX | -- | -- | |
+            // | -- | -- | XX | XX | XX | XX | XX | XX | -- | -- | |_height
+            // | -- | -- | XX | XX | XX | XX | XX | XX | -- | -- |_|
+            // | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+            // | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+            // ...__pitch__/
+            //
+            // The indexing logic works on nint values in unchecked mode, with no overflow checks,
+            // which means it relies on the maximum element index to always be within <= nint.MaxValue.
+            // To ensure no overflows will ever occur there, we need to ensure that no instance can be
+            // created with parameters that could cause an overflow in case any item was accessed, so we
+            // need to ensure no overflows occurs when calculating the index of the last item in each view.
+            // The logic below calculates that index with overflow checks, throwing if one is detected.
+            // Note that we're subtracting 1 to the height as we don't want to include the trailing pitch
+            // for the 2D memory area, and also 1 to the width as the index is 0-based, as usual.
+            _ = checked((((nint)width + pitch) * Max(unchecked(height - 1), 0)) + Max(unchecked(width - 1), 0));
+        }
+    }
+}

--- a/Microsoft.Toolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
@@ -42,7 +42,10 @@ namespace Microsoft.Toolkit.HighPerformance.Memory.Internals
             // The logic below calculates that index with overflow checks, throwing if one is detected.
             // Note that we're subtracting 1 to the height as we don't want to include the trailing pitch
             // for the 2D memory area, and also 1 to the width as the index is 0-based, as usual.
-            _ = checked((((nint)width + pitch) * Max(unchecked(height - 1), 0)) + Max(unchecked(width - 1), 0));
+            // Additionally, we're also ensuring that the stride is never greater than int.MaxValue, for
+            // consistency with how ND arrays work (int.MaxValue as upper bound for each axis), and to
+            // allow for faster iteration in the RefEnumerable<T> type, when traversing columns.
+            _ = checked(((nint)(width + pitch) * Max(unchecked(height - 1), 0)) + Max(unchecked(width - 1), 0));
         }
 
         /// <summary>

--- a/Microsoft.Toolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Internals/OverflowHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 using static System.Math;
 
 namespace Microsoft.Toolkit.HighPerformance.Memory.Internals
@@ -14,6 +16,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory.Internals
         /// <param name="height">The height of the 2D memory area to map.</param>
         /// <param name="width">The width of the 2D memory area to map.</param>
         /// <param name="pitch">The pitch of the 2D memory area to map (the distance between each row).</param>
+        /// <exception cref="OverflowException">Throw when the inputs don't fit in the expected range.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void EnsureIsInNativeIntRange(int height, int width, int pitch)
         {
@@ -40,6 +43,21 @@ namespace Microsoft.Toolkit.HighPerformance.Memory.Internals
             // Note that we're subtracting 1 to the height as we don't want to include the trailing pitch
             // for the 2D memory area, and also 1 to the width as the index is 0-based, as usual.
             _ = checked((((nint)width + pitch) * Max(unchecked(height - 1), 0)) + Max(unchecked(width - 1), 0));
+        }
+
+        /// <summary>
+        /// Ensures that the input parameters will not exceed the maximum native int value when indexing.
+        /// </summary>
+        /// <param name="height">The height of the 2D memory area to map.</param>
+        /// <param name="width">The width of the 2D memory area to map.</param>
+        /// <param name="pitch">The pitch of the 2D memory area to map (the distance between each row).</param>
+        /// <returns>The area resulting from the given parameters.</returns>
+        /// <exception cref="OverflowException">Throw when the inputs don't fit in the expected range.</exception>
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ComputeInt32Area(int height, int width, int pitch)
+        {
+            return checked(((width + pitch) * Max(unchecked(height - 1), 0)) + width);
         }
     }
 }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <summary>
         /// Gets the length of the current <see cref="Memory2D{T}"/> instance.
         /// </summary>
-        public int Size
+        public int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Height * Width;
@@ -771,7 +771,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 {
                     string text = Unsafe.As<string>(this.instance);
                     int index = text.AsSpan().IndexOf(in text.DangerousGetObjectDataReferenceAt<char>(this.offset));
-                    ReadOnlyMemory<char> temp = text.AsMemory(index, Size);
+                    ReadOnlyMemory<char> temp = text.AsMemory(index, Length);
 
                     // The string type could still be present if a user ends up creating a
                     // Memory2D<T> instance from a string using DangerousCreate. Similarly to

--- a/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -567,10 +567,10 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <summary>
         /// Gets the length of the current <see cref="Memory2D{T}"/> instance.
         /// </summary>
-        public int Length
+        public nint Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Height * Width;
+            get => (nint)(uint)this.height * (nint)(uint)this.width;
         }
 
         /// <summary>
@@ -754,13 +754,14 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         }
 
         /// <summary>
-        /// Tries to get a <see cref="Memory{T}"/> instance, if the underlying buffer is contiguous.
+        /// Tries to get a <see cref="Memory{T}"/> instance, if the underlying buffer is contiguous and small enough.
         /// </summary>
         /// <param name="memory">The resulting <see cref="Memory{T}"/>, in case of success.</param>
         /// <returns>Whether or not <paramref name="memory"/> was correctly assigned.</returns>
         public bool TryGetMemory(out Memory<T> memory)
         {
-            if (this.pitch == 0)
+            if (this.pitch == 0 &&
+                Length <= int.MaxValue)
             {
                 // Empty Memory2D<T> instance
                 if (this.instance is null)
@@ -771,7 +772,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 {
                     string text = Unsafe.As<string>(this.instance);
                     int index = text.AsSpan().IndexOf(in text.DangerousGetObjectDataReferenceAt<char>(this.offset));
-                    ReadOnlyMemory<char> temp = text.AsMemory(index, Length);
+                    ReadOnlyMemory<char> temp = text.AsMemory(index, (int)Length);
 
                     // The string type could still be present if a user ends up creating a
                     // Memory2D<T> instance from a string using DangerousCreate. Similarly to

--- a/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -381,12 +381,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             this.instance = memoryManager;
-
-            unsafe
-            {
-                this.offset = (IntPtr)(void*)(uint)offset;
-            }
-
+            this.offset = (nint)(uint)offset;
             this.height = height;
             this.width = width;
             this.pitch = pitch;
@@ -485,11 +480,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             else if (MemoryMarshal.TryGetMemoryManager<T, MemoryManager<T>>(memory, out var memoryManager, out int memoryManagerStart, out _))
             {
                 this.instance = memoryManager;
-
-                unsafe
-                {
-                    this.offset = (IntPtr)(void*)(uint)(memoryManagerStart + offset);
-                }
+                this.offset = (nint)(uint)(memoryManagerStart + offset);
             }
             else
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Memory2D{T}.cs
@@ -118,8 +118,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = array.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = array.Length - offset;
 
             if (area > remaining)
             {
@@ -372,8 +372,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = length - offset;
 
             if (area > remaining)
             {
@@ -451,8 +451,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = memory.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = memory.Length - offset;
 
             if (area > remaining)
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -104,8 +104,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = text.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = text.Length - offset;
 
             if (area > remaining)
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -182,8 +182,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = array.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = array.Length - offset;
 
             if (area > remaining)
             {
@@ -436,8 +436,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = length - offset;
 
             if (area > remaining)
             {
@@ -515,8 +515,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = memory.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = memory.Length - offset;
 
             if (area > remaining)
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -624,10 +624,10 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <summary>
         /// Gets the length of the current <see cref="ReadOnlyMemory2D{T}"/> instance.
         /// </summary>
-        public int Length
+        public nint Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Height * Width;
+            get => (nint)(uint)this.height * (nint)(uint)this.width;
         }
 
         /// <summary>
@@ -812,13 +812,14 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         }
 
         /// <summary>
-        /// Tries to get a <see cref="ReadOnlyMemory{T}"/> instance, if the underlying buffer is contiguous.
+        /// Tries to get a <see cref="ReadOnlyMemory{T}"/> instance, if the underlying buffer is contiguous and small enough.
         /// </summary>
         /// <param name="memory">The resulting <see cref="ReadOnlyMemory{T}"/>, in case of success.</param>
         /// <returns>Whether or not <paramref name="memory"/> was correctly assigned.</returns>
         public bool TryGetMemory(out ReadOnlyMemory<T> memory)
         {
-            if (this.pitch == 0)
+            if (this.pitch == 0 &&
+                Length <= int.MaxValue)
             {
                 // Empty Memory2D<T> instance
                 if (this.instance is null)
@@ -829,7 +830,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 {
                     string text = Unsafe.As<string>(this.instance);
                     int index = text.AsSpan().IndexOf(in text.DangerousGetObjectDataReferenceAt<char>(this.offset));
-                    ReadOnlyMemory<char> temp = text.AsMemory(index, Length);
+                    ReadOnlyMemory<char> temp = text.AsMemory(index, (int)Length);
 
                     memory = Unsafe.As<ReadOnlyMemory<char>, ReadOnlyMemory<T>>(ref temp);
                 }

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -624,7 +624,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <summary>
         /// Gets the length of the current <see cref="ReadOnlyMemory2D{T}"/> instance.
         /// </summary>
-        public int Size
+        public int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Height * Width;
@@ -829,7 +829,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 {
                     string text = Unsafe.As<string>(this.instance);
                     int index = text.AsSpan().IndexOf(in text.DangerousGetObjectDataReferenceAt<char>(this.offset));
-                    ReadOnlyMemory<char> temp = text.AsMemory(index, Size);
+                    ReadOnlyMemory<char> temp = text.AsMemory(index, Length);
 
                     memory = Unsafe.As<ReadOnlyMemory<char>, ReadOnlyMemory<T>>(ref temp);
                 }

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlyMemory2D{T}.cs
@@ -445,12 +445,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             this.instance = memoryManager;
-
-            unsafe
-            {
-                this.offset = (IntPtr)(void*)(uint)offset;
-            }
-
+            this.offset = (nint)(uint)offset;
             this.height = height;
             this.width = width;
             this.pitch = pitch;
@@ -542,11 +537,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             else if (MemoryMarshal.TryGetMemoryManager<T, MemoryManager<T>>(memory, out var memoryManager, out int memoryManagerStart, out _))
             {
                 this.instance = memoryManager;
-
-                unsafe
-                {
-                    this.offset = (IntPtr)(void*)(uint)(memoryManagerStart + offset);
-                }
+                this.offset = (nint)(uint)(memoryManagerStart + offset);
             }
             else
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForRow();
             }
 
-            int startIndex = (this.width + this.pitch) * row;
+            nint startIndex = (nint)(uint)(this.width + this.pitch) * (nint)(uint)row;
             ref T r0 = ref DangerousGetReference();
-            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)startIndex);
+            ref T r1 = ref Unsafe.Add(ref r0, startIndex);
 
 #if SPAN_RUNTIME_SUPPORT
             return new ReadOnlyRefEnumerable<T>(r1, Width, 1);
@@ -191,9 +191,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #else
                     ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
 #endif
-                    int index = (this.y * (this.width + this.pitch)) + this.x;
+                    nint index = ((nint)(uint)this.y * (nint)(uint)(this.width + this.pitch)) + (nint)(uint)this.x;
 
-                    return ref Unsafe.Add(ref r0, (nint)(uint)index);
+                    return ref Unsafe.Add(ref r0, index);
                 }
             }
         }

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.Enumerator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <remarks>The returned <see cref="ReadOnlyRefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe ReadOnlyRefEnumerable<T> GetRow(int row)
+        public ReadOnlyRefEnumerable<T> GetRow(int row)
         {
             if ((uint)row >= Height)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 
             int startIndex = (this.width + this.pitch) * row;
             ref T r0 = ref DangerousGetReference();
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)startIndex);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)startIndex);
 
 #if SPAN_RUNTIME_SUPPORT
             return new ReadOnlyRefEnumerable<T>(r1, Width, 1);
@@ -54,7 +54,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <remarks>The returned <see cref="ReadOnlyRefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe ReadOnlyRefEnumerable<T> GetColumn(int column)
+        public ReadOnlyRefEnumerable<T> GetColumn(int column)
         {
             if ((uint)column >= Width)
             {
@@ -62,7 +62,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             ref T r0 = ref DangerousGetReference();
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)column);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)column);
 
 #if SPAN_RUNTIME_SUPPORT
             return new ReadOnlyRefEnumerable<T>(r1, Height, this.width + this.pitch);
@@ -181,7 +181,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             /// <summary>
             /// Gets the duck-typed <see cref="System.Collections.Generic.IEnumerator{T}.Current"/> property.
             /// </summary>
-            public readonly unsafe ref readonly T Current
+            public readonly ref readonly T Current
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -193,7 +193,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #endif
                     int index = (this.y * (this.width + this.pitch)) + this.x;
 
-                    return ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)index);
+                    return ref Unsafe.Add(ref r0, (nint)(uint)index);
                 }
             }
         }

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -104,6 +104,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
             }
 
+            OverflowHelper.EnsureIsInNativeIntRange(height, width, pitch);
+
 #if SPAN_RUNTIME_SUPPORT
             this.span = new ReadOnlySpan<T>(pointer, height);
 #else
@@ -205,8 +207,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = array.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = array.Length - offset;
 
             if (area > remaining)
             {
@@ -477,8 +479,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = span.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = span.Length - offset;
 
             if (area > remaining)
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <summary>
         /// Gets the length of the current <see cref="ReadOnlySpan2D{T}"/> instance.
         /// </summary>
-        public int Size
+        public int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Height * Width;
@@ -653,7 +653,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
             else
             {
-                if (Size > destination.Length)
+                if (Length > destination.Length)
                 {
                     ThrowHelper.ThrowArgumentExceptionForDestinationTooShort();
                 }
@@ -742,7 +742,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <returns>Whether or not the operation was successful.</returns>
         public bool TryCopyTo(Span<T> destination)
         {
-            if (destination.Length >= Size)
+            if (destination.Length >= Length)
             {
                 CopyTo(destination);
 
@@ -783,7 +783,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         {
             ref T r0 = ref Unsafe.AsRef<T>(null);
 
-            if (Size != 0)
+            if (Length != 0)
             {
 #if SPAN_RUNTIME_SUPPORT
                 r0 = ref MemoryMarshal.GetReference(this.span);
@@ -913,7 +913,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             if (this.pitch == 0)
             {
 #if SPAN_RUNTIME_SUPPORT
-                span = MemoryMarshal.CreateReadOnlySpan(ref MemoryMarshal.GetReference(this.span), Size);
+                span = MemoryMarshal.CreateReadOnlySpan(ref MemoryMarshal.GetReference(this.span), Length);
 
                 return true;
 #else
@@ -930,7 +930,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 {
                     unsafe
                     {
-                        span = new Span<T>((void*)this.offset, Size);
+                        span = new Span<T>((void*)this.offset, Length);
                     }
 
                     return true;
@@ -939,7 +939,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 // Without Span<T> runtime support, we can only get a Span<T> from a T[] instance
                 if (this.instance.GetType() == typeof(T[]))
                 {
-                    span = Unsafe.As<T[]>(this.instance).AsSpan((int)this.offset, Size);
+                    span = Unsafe.As<T[]>(this.instance).AsSpan((int)this.offset, Length);
 
                     return true;
                 }
@@ -964,7 +964,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             CopyTo(array.AsSpan());
 #else
             // Skip the initialization if the array is empty
-            if (Size > 0)
+            if (Length > 0)
             {
                 int height = Height;
                 nint width = (nint)(uint)this.width;

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -825,9 +825,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #else
             ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
 #endif
-            int index = (i * (this.width + this.pitch)) + j;
+            nint index = ((nint)(uint)i * (nint)(uint)(this.width + this.pitch)) + (nint)(uint)j;
 
-            return ref Unsafe.Add(ref r0, (nint)(uint)index);
+            return ref Unsafe.Add(ref r0, index);
         }
 
         /// <summary>
@@ -865,16 +865,15 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForHeight();
             }
 
-            int
-                shift = ((this.width + this.pitch) * row) + column,
-                pitch = this.pitch + (this.width - width);
+            nint shift = ((nint)(uint)(this.width + this.pitch) * (nint)(uint)row) + (nint)(uint)column;
+            int pitch = this.pitch + (this.width - width);
 
 #if SPAN_RUNTIME_SUPPORT
             ref T r0 = ref this.span.DangerousGetReferenceAt(shift);
 
             return new ReadOnlySpan2D<T>(r0, height, width, pitch);
 #else
-            IntPtr offset = this.offset + (shift * Unsafe.SizeOf<T>());
+            IntPtr offset = this.offset + (shift * (nint)(uint)Unsafe.SizeOf<T>());
 
             return new ReadOnlySpan2D<T>(this.instance, offset, height, width, pitch);
 #endif
@@ -895,9 +894,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForRow();
             }
 
-            int offset = (this.width + this.pitch) * row;
+            nint offset = (nint)(uint)(this.width + this.pitch) * (nint)(uint)row;
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
-            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)offset);
+            ref T r1 = ref Unsafe.Add(ref r0, offset);
 
             return MemoryMarshal.CreateReadOnlySpan(ref r1, this.width);
         }

--- a/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/ReadOnlySpan2D{T}.cs
@@ -665,22 +665,19 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                     GetRowSpan(i).CopyTo(destination.Slice(j));
                 }
 #else
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                ref T destinationRef = ref MemoryMarshal.GetReference(destination);
+                nint offset = 0;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
 
-                    ref T destinationRef = ref MemoryMarshal.GetReference(destination);
-                    IntPtr offset = default;
-
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1, offset += 1)
                     {
-                        ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1, offset += 1)
-                        {
-                            Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
-                        }
+                        Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
                     }
                 }
 #endif
@@ -721,20 +718,17 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                     GetRowSpan(i).CopyTo(destination.GetRowSpan(i));
                 }
 #else
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
+                    ref T destinationRef = ref destination.DangerousGetReferenceAt(i, 0);
 
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1)
                     {
-                        ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
-                        ref T destinationRef = ref destination.DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1)
-                        {
-                            Unsafe.Add(ref destinationRef, j) = Unsafe.Add(ref sourceRef, j);
-                        }
+                        Unsafe.Add(ref destinationRef, j) = Unsafe.Add(ref sourceRef, j);
                     }
                 }
 #endif
@@ -824,7 +818,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <returns>A reference to the element at the specified indices.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe ref T DangerousGetReferenceAt(int i, int j)
+        public ref T DangerousGetReferenceAt(int i, int j)
         {
 #if SPAN_RUNTIME_SUPPORT
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
@@ -833,7 +827,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #endif
             int index = (i * (this.width + this.pitch)) + j;
 
-            return ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)index);
+            return ref Unsafe.Add(ref r0, (nint)(uint)index);
         }
 
         /// <summary>
@@ -894,7 +888,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <exception cref="ArgumentOutOfRangeException">Throw when <paramref name="row"/> is out of range.</exception>
         /// <returns>The resulting row <see cref="ReadOnlySpan{T}"/>.</returns>
         [Pure]
-        public unsafe ReadOnlySpan<T> GetRowSpan(int row)
+        public ReadOnlySpan<T> GetRowSpan(int row)
         {
             if ((uint)row >= (uint)Height)
             {
@@ -903,7 +897,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 
             int offset = (this.width + this.pitch) * row;
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)offset);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)offset);
 
             return MemoryMarshal.CreateReadOnlySpan(ref r1, this.width);
         }
@@ -973,22 +967,19 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             // Skip the initialization if the array is empty
             if (Size > 0)
             {
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                ref T destinationRef = ref array.DangerousGetReference();
+                nint offset = 0;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
 
-                    ref T destinationRef = ref array.DangerousGetReference();
-                    IntPtr offset = default;
-
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1, offset += 1)
                     {
-                        ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1, offset += 1)
-                        {
-                            Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
-                        }
+                        Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
                     }
                 }
             }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <remarks>The returned <see cref="RefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe RefEnumerable<T> GetRow(int row)
+        public RefEnumerable<T> GetRow(int row)
         {
             if ((uint)row >= Height)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 
             int startIndex = (this.width + this.Pitch) * row;
             ref T r0 = ref DangerousGetReference();
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)startIndex);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)startIndex);
 
 #if SPAN_RUNTIME_SUPPORT
             return new RefEnumerable<T>(ref r1, Width, 1);
@@ -54,7 +54,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <remarks>The returned <see cref="RefEnumerable{T}"/> value shouldn't be used directly: use this extension in a <see langword="foreach"/> loop.</remarks>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe RefEnumerable<T> GetColumn(int column)
+        public RefEnumerable<T> GetColumn(int column)
         {
             if ((uint)column >= Width)
             {
@@ -62,7 +62,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             ref T r0 = ref DangerousGetReference();
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)column);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)column);
 
 #if SPAN_RUNTIME_SUPPORT
             return new RefEnumerable<T>(ref r1, Height, this.width + this.Pitch);
@@ -181,7 +181,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             /// <summary>
             /// Gets the duck-typed <see cref="System.Collections.Generic.IEnumerator{T}.Current"/> property.
             /// </summary>
-            public readonly unsafe ref T Current
+            public readonly ref T Current
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
@@ -193,7 +193,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #endif
                     int index = (this.y * (this.width + this.pitch)) + this.x;
 
-                    return ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)index);
+                    return ref Unsafe.Add(ref r0, (nint)(uint)index);
                 }
             }
         }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.Enumerator.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForRow();
             }
 
-            int startIndex = (this.width + this.Pitch) * row;
+            nint startIndex = (nint)(uint)(this.width + this.Pitch) * (nint)(uint)row;
             ref T r0 = ref DangerousGetReference();
-            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)startIndex);
+            ref T r1 = ref Unsafe.Add(ref r0, startIndex);
 
 #if SPAN_RUNTIME_SUPPORT
             return new RefEnumerable<T>(ref r1, Width, 1);
@@ -191,9 +191,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #else
                     ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.instance, this.offset);
 #endif
-                    int index = (this.y * (this.width + this.pitch)) + this.x;
+                    nint index = ((nint)(uint)this.y * (nint)(uint)(this.width + this.pitch)) + (nint)(uint)this.x;
 
-                    return ref Unsafe.Add(ref r0, (nint)(uint)index);
+                    return ref Unsafe.Add(ref r0, index);
                 }
             }
         }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -678,19 +678,16 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                     GetRowSpan(i).Clear();
                 }
 #else
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T r0 = ref DangerousGetReferenceAt(i, 0);
 
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1)
                     {
-                        ref T r0 = ref DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1)
-                        {
-                            Unsafe.Add(ref r0, j) = default!;
-                        }
+                        Unsafe.Add(ref r0, j) = default!;
                     }
                 }
 #endif
@@ -729,22 +726,19 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                     GetRowSpan(i).CopyTo(destination.Slice(j));
                 }
 #else
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                ref T destinationRef = ref MemoryMarshal.GetReference(destination);
+                nint offset = 0;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
 
-                    ref T destinationRef = ref MemoryMarshal.GetReference(destination);
-                    IntPtr offset = default;
-
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1, offset += 1)
                     {
-                        ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1, offset += 1)
-                        {
-                            Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
-                        }
+                        Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
                     }
                 }
 #endif
@@ -785,20 +779,17 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                     GetRowSpan(i).CopyTo(destination.GetRowSpan(i));
                 }
 #else
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
+                    ref T destinationRef = ref destination.DangerousGetReferenceAt(i, 0);
 
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1)
                     {
-                        ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
-                        ref T destinationRef = ref destination.DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1)
-                        {
-                            Unsafe.Add(ref destinationRef, j) = Unsafe.Add(ref sourceRef, j);
-                        }
+                        Unsafe.Add(ref destinationRef, j) = Unsafe.Add(ref sourceRef, j);
                     }
                 }
 #endif
@@ -864,19 +855,16 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                     GetRowSpan(i).Fill(value);
                 }
 #else
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T r0 = ref DangerousGetReferenceAt(i, 0);
 
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1)
                     {
-                        ref T r0 = ref DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1)
-                        {
-                            Unsafe.Add(ref r0, j) = value;
-                        }
+                        Unsafe.Add(ref r0, j) = value;
                     }
                 }
 #endif
@@ -931,7 +919,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <returns>A reference to the element at the specified indices.</returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe ref T DangerousGetReferenceAt(int i, int j)
+        public ref T DangerousGetReferenceAt(int i, int j)
         {
 #if SPAN_RUNTIME_SUPPORT
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
@@ -940,7 +928,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #endif
             int index = (i * (this.width + this.Pitch)) + j;
 
-            return ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)index);
+            return ref Unsafe.Add(ref r0, (nint)(uint)index);
         }
 
         /// <summary>
@@ -1001,7 +989,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <exception cref="ArgumentOutOfRangeException">Throw when <paramref name="row"/> is out of range.</exception>
         /// <returns>The resulting row <see cref="Span{T}"/>.</returns>
         [Pure]
-        public unsafe Span<T> GetRowSpan(int row)
+        public Span<T> GetRowSpan(int row)
         {
             if ((uint)row >= (uint)Height)
             {
@@ -1010,7 +998,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 
             int offset = (this.width + this.Pitch) * row;
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
-            ref T r1 = ref Unsafe.Add(ref r0, (IntPtr)(void*)(uint)offset);
+            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)offset);
 
             return MemoryMarshal.CreateSpan(ref r1, this.width);
         }
@@ -1080,22 +1068,19 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             // Skip the initialization if the array is empty
             if (Size > 0)
             {
-                unsafe
+                int height = Height;
+                nint width = (nint)(uint)this.width;
+
+                ref T destinationRef = ref array.DangerousGetReference();
+                nint offset = 0;
+
+                for (int i = 0; i < height; i++)
                 {
-                    int height = Height;
-                    IntPtr width = (IntPtr)(void*)(uint)this.width;
+                    ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
 
-                    ref T destinationRef = ref array.DangerousGetReference();
-                    IntPtr offset = default;
-
-                    for (int i = 0; i < height; i++)
+                    for (nint j = 0; j < width; j += 1, offset += 1)
                     {
-                        ref T sourceRef = ref DangerousGetReferenceAt(i, 0);
-
-                        for (IntPtr j = default; (void*)j < (void*)width; j += 1, offset += 1)
-                        {
-                            Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
-                        }
+                        Unsafe.Add(ref destinationRef, offset) = Unsafe.Add(ref sourceRef, j);
                     }
                 }
             }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -133,6 +133,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForPitch();
             }
 
+            OverflowHelper.EnsureIsInNativeIntRange(height, width, pitch);
+
 #if SPAN_RUNTIME_SUPPORT
             this.span = new Span<T>(pointer, height);
 #else
@@ -227,8 +229,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = array.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = array.Length - offset;
 
             if (area > remaining)
             {
@@ -499,8 +501,8 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
 
             int
-                remaining = span.Length - offset,
-                area = ((width + pitch) * (height - 1)) + width;
+                area = OverflowHelper.ComputeInt32Area(height, width, pitch),
+                remaining = span.Length - offset;
 
             if (area > remaining)
             {

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -926,9 +926,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
 #else
             ref T r0 = ref RuntimeHelpers.GetObjectDataAtOffsetOrPointerReference<T>(this.Instance, this.Offset);
 #endif
-            int index = (i * (this.width + this.Pitch)) + j;
+            nint index = ((nint)(uint)i * (nint)(uint)(this.width + this.Pitch)) + (nint)(uint)j;
 
-            return ref Unsafe.Add(ref r0, (nint)(uint)index);
+            return ref Unsafe.Add(ref r0, index);
         }
 
         /// <summary>
@@ -966,16 +966,15 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForWidth();
             }
 
-            int
-                shift = ((this.width + this.Pitch) * row) + column,
-                pitch = this.Pitch + (this.width - width);
+            nint shift = ((nint)(uint)(this.width + this.Pitch) * (nint)(uint)row) + (nint)(uint)column;
+            int pitch = this.Pitch + (this.width - width);
 
 #if SPAN_RUNTIME_SUPPORT
             ref T r0 = ref this.span.DangerousGetReferenceAt(shift);
 
             return new Span2D<T>(ref r0, height, width, pitch);
 #else
-            IntPtr offset = this.Offset + (shift * Unsafe.SizeOf<T>());
+            IntPtr offset = this.Offset + (shift * (nint)(uint)Unsafe.SizeOf<T>());
 
             return new Span2D<T>(this.Instance, offset, height, width, pitch);
 #endif
@@ -996,9 +995,9 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 ThrowHelper.ThrowArgumentOutOfRangeExceptionForRow();
             }
 
-            int offset = (this.width + this.Pitch) * row;
+            nint offset = (nint)(uint)(this.width + this.Pitch) * (nint)(uint)row;
             ref T r0 = ref MemoryMarshal.GetReference(this.span);
-            ref T r1 = ref Unsafe.Add(ref r0, (nint)(uint)offset);
+            ref T r1 = ref Unsafe.Add(ref r0, offset);
 
             return MemoryMarshal.CreateSpan(ref r1, this.width);
         }

--- a/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
+++ b/Microsoft.Toolkit.HighPerformance/Memory/Span2D{T}.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <summary>
         /// Gets the length of the current <see cref="Span2D{T}"/> instance.
         /// </summary>
-        public int Size
+        public int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => Height * this.width;
@@ -714,7 +714,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             }
             else
             {
-                if (Size > destination.Length)
+                if (Length > destination.Length)
                 {
                     ThrowHelper.ThrowArgumentExceptionForDestinationTooShort();
                 }
@@ -803,7 +803,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         /// <returns>Whether or not the operation was successful.</returns>
         public bool TryCopyTo(Span<T> destination)
         {
-            if (destination.Length >= Size)
+            if (destination.Length >= Length)
             {
                 CopyTo(destination);
 
@@ -884,7 +884,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
         {
             ref T r0 = ref Unsafe.AsRef<T>(null);
 
-            if (Size != 0)
+            if (Length != 0)
             {
 #if SPAN_RUNTIME_SUPPORT
                 r0 = ref MemoryMarshal.GetReference(this.span);
@@ -1014,7 +1014,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             if (this.Pitch == 0)
             {
 #if SPAN_RUNTIME_SUPPORT
-                span = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(this.span), Size);
+                span = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(this.span), Length);
 
                 return true;
 #else
@@ -1031,7 +1031,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 {
                     unsafe
                     {
-                        span = new Span<T>((void*)this.Offset, Size);
+                        span = new Span<T>((void*)this.Offset, Length);
                     }
 
                     return true;
@@ -1040,7 +1040,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
                 // Without Span<T> runtime support, we can only get a Span<T> from a T[] instance
                 if (this.Instance.GetType() == typeof(T[]))
                 {
-                    span = Unsafe.As<T[]>(this.Instance).AsSpan((int)this.Offset, Size);
+                    span = Unsafe.As<T[]>(this.Instance).AsSpan((int)this.Offset, Length);
 
                     return true;
                 }
@@ -1065,7 +1065,7 @@ namespace Microsoft.Toolkit.HighPerformance.Memory
             CopyTo(array.AsSpan());
 #else
             // Skip the initialization if the array is empty
-            if (Size > 0)
+            if (Length > 0)
             {
                 int height = Height;
                 nint width = (nint)(uint)this.width;

--- a/Microsoft.Toolkit.HighPerformance/Microsoft.Toolkit.HighPerformance.csproj
+++ b/Microsoft.Toolkit.HighPerformance/Microsoft.Toolkit.HighPerformance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Title>Windows Community Toolkit High Performance .NET Standard</Title>

--- a/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_ParallelHelper.ForEach.In2D.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_ParallelHelper.ForEach.In2D.cs
@@ -37,7 +37,7 @@ namespace UnitTests.HighPerformance.Helpers
 
             ReadOnlyMemory2D<int> memory = data.AsMemory2D(row, column, height, width);
 
-            Assert.AreEqual(memory.Size, height * width);
+            Assert.AreEqual(memory.Length, height * width);
             Assert.AreEqual(memory.Height, height);
             Assert.AreEqual(memory.Width, width);
 

--- a/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_ParallelHelper.ForEach.Ref2D.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Helpers/Test_ParallelHelper.ForEach.Ref2D.cs
@@ -40,7 +40,7 @@ namespace UnitTests.HighPerformance.Helpers
 
             Memory2D<int> memory = data.AsMemory2D(row, column, height, width);
 
-            Assert.AreEqual(memory.Size, height * width);
+            Assert.AreEqual(memory.Length, height * width);
             Assert.AreEqual(memory.Height, height);
             Assert.AreEqual(memory.Width, width);
 

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Memory2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Memory2D{T}.cs
@@ -24,28 +24,28 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> empty1 = default;
 
             Assert.IsTrue(empty1.IsEmpty);
-            Assert.AreEqual(empty1.Size, 0);
+            Assert.AreEqual(empty1.Length, 0);
             Assert.AreEqual(empty1.Width, 0);
             Assert.AreEqual(empty1.Height, 0);
 
             Memory2D<string> empty2 = Memory2D<string>.Empty;
 
             Assert.IsTrue(empty2.IsEmpty);
-            Assert.AreEqual(empty2.Size, 0);
+            Assert.AreEqual(empty2.Length, 0);
             Assert.AreEqual(empty2.Width, 0);
             Assert.AreEqual(empty2.Height, 0);
 
             Memory2D<int> empty3 = new int[4, 0];
 
             Assert.IsTrue(empty3.IsEmpty);
-            Assert.AreEqual(empty3.Size, 0);
+            Assert.AreEqual(empty3.Length, 0);
             Assert.AreEqual(empty3.Width, 0);
             Assert.AreEqual(empty3.Height, 4);
 
             Memory2D<int> empty4 = new int[0, 7];
 
             Assert.IsTrue(empty4.IsEmpty);
-            Assert.AreEqual(empty4.Size, 0);
+            Assert.AreEqual(empty4.Length, 0);
             Assert.AreEqual(empty4.Width, 7);
             Assert.AreEqual(empty4.Height, 0);
         }
@@ -62,7 +62,7 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> memory2d = new Memory2D<int>(array, 1, 2, 2, 1);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 2);
@@ -89,7 +89,7 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> memory2d = new Memory2D<int>(array);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 6);
+            Assert.AreEqual(memory2d.Length, 6);
             Assert.AreEqual(memory2d.Width, 3);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 1], 2);
@@ -111,7 +111,7 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> memory2d = new Memory2D<int>(array, 0, 1, 2, 2);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 2);
@@ -139,7 +139,7 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> memory2d = new Memory2D<int>(array, 1);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 6);
+            Assert.AreEqual(memory2d.Length, 6);
             Assert.AreEqual(memory2d.Width, 3);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 1], 20);
@@ -168,7 +168,7 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> memory2d = new Memory2D<int>(array, 1, 0, 1, 2, 2);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 20);
@@ -194,7 +194,7 @@ namespace UnitTests.HighPerformance.Memory
             Memory2D<int> memory2d = memory.AsMemory2D(1, 2, 2, 1);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 2);
@@ -222,7 +222,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Memory2D<int> slice1 = memory2d.Slice(1, 1, 1, 2);
 
-            Assert.AreEqual(slice1.Size, 2);
+            Assert.AreEqual(slice1.Length, 2);
             Assert.AreEqual(slice1.Height, 1);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1.Span[0, 0], 5);
@@ -230,7 +230,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Memory2D<int> slice2 = memory2d.Slice(0, 1, 2, 2);
 
-            Assert.AreEqual(slice2.Size, 4);
+            Assert.AreEqual(slice2.Length, 4);
             Assert.AreEqual(slice2.Height, 2);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2.Span[0, 0], 2);
@@ -260,7 +260,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Memory2D<int> slice1 = memory2d.Slice(0, 0, 2, 2);
 
-            Assert.AreEqual(slice1.Size, 4);
+            Assert.AreEqual(slice1.Length, 4);
             Assert.AreEqual(slice1.Height, 2);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1.Span[0, 0], 1);
@@ -268,7 +268,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Memory2D<int> slice2 = slice1.Slice(1, 0, 1, 2);
 
-            Assert.AreEqual(slice2.Size, 2);
+            Assert.AreEqual(slice2.Length, 2);
             Assert.AreEqual(slice2.Height, 1);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2.Span[0, 0], 4);
@@ -276,7 +276,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Memory2D<int> slice3 = slice2.Slice(0, 1, 1, 1);
 
-            Assert.AreEqual(slice3.Size, 1);
+            Assert.AreEqual(slice3.Length, 1);
             Assert.AreEqual(slice3.Height, 1);
             Assert.AreEqual(slice3.Width, 1);
             Assert.AreEqual(slice3.Span[0, 0], 5);

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlyMemory2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlyMemory2D{T}.cs
@@ -24,14 +24,14 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> empty1 = default;
 
             Assert.IsTrue(empty1.IsEmpty);
-            Assert.AreEqual(empty1.Size, 0);
+            Assert.AreEqual(empty1.Length, 0);
             Assert.AreEqual(empty1.Width, 0);
             Assert.AreEqual(empty1.Height, 0);
 
             ReadOnlyMemory2D<string> empty2 = ReadOnlyMemory2D<string>.Empty;
 
             Assert.IsTrue(empty2.IsEmpty);
-            Assert.AreEqual(empty2.Size, 0);
+            Assert.AreEqual(empty2.Length, 0);
             Assert.AreEqual(empty2.Width, 0);
             Assert.AreEqual(empty2.Height, 0);
         }
@@ -48,7 +48,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> memory2d = new ReadOnlyMemory2D<int>(array, 1, 2, 2, 1);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 2);
@@ -75,7 +75,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> memory2d = new ReadOnlyMemory2D<int>(array);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 6);
+            Assert.AreEqual(memory2d.Length, 6);
             Assert.AreEqual(memory2d.Width, 3);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 1], 2);
@@ -97,7 +97,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> memory2d = new ReadOnlyMemory2D<int>(array, 0, 1, 2, 2);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 2);
@@ -125,7 +125,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> memory2d = new ReadOnlyMemory2D<int>(array, 1);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 6);
+            Assert.AreEqual(memory2d.Length, 6);
             Assert.AreEqual(memory2d.Width, 3);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 1], 20);
@@ -154,7 +154,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> memory2d = new ReadOnlyMemory2D<int>(array, 1, 0, 1, 2, 2);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 20);
@@ -180,7 +180,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlyMemory2D<int> memory2d = memory.AsMemory2D(1, 2, 2, 1);
 
             Assert.IsFalse(memory2d.IsEmpty);
-            Assert.AreEqual(memory2d.Size, 4);
+            Assert.AreEqual(memory2d.Length, 4);
             Assert.AreEqual(memory2d.Width, 2);
             Assert.AreEqual(memory2d.Height, 2);
             Assert.AreEqual(memory2d.Span[0, 0], 2);
@@ -208,7 +208,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlyMemory2D<int> slice1 = memory2d.Slice(1, 1, 1, 2);
 
-            Assert.AreEqual(slice1.Size, 2);
+            Assert.AreEqual(slice1.Length, 2);
             Assert.AreEqual(slice1.Height, 1);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1.Span[0, 0], 5);
@@ -216,7 +216,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlyMemory2D<int> slice2 = memory2d.Slice(0, 1, 2, 2);
 
-            Assert.AreEqual(slice2.Size, 4);
+            Assert.AreEqual(slice2.Length, 4);
             Assert.AreEqual(slice2.Height, 2);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2.Span[0, 0], 2);
@@ -246,7 +246,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlyMemory2D<int> slice1 = memory2d.Slice(0, 0, 2, 2);
 
-            Assert.AreEqual(slice1.Size, 4);
+            Assert.AreEqual(slice1.Length, 4);
             Assert.AreEqual(slice1.Height, 2);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1.Span[0, 0], 1);
@@ -254,7 +254,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlyMemory2D<int> slice2 = slice1.Slice(1, 0, 1, 2);
 
-            Assert.AreEqual(slice2.Size, 2);
+            Assert.AreEqual(slice2.Length, 2);
             Assert.AreEqual(slice2.Height, 1);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2.Span[0, 0], 4);
@@ -262,7 +262,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlyMemory2D<int> slice3 = slice2.Slice(0, 1, 1, 1);
 
-            Assert.AreEqual(slice3.Size, 1);
+            Assert.AreEqual(slice3.Length, 1);
             Assert.AreEqual(slice3.Height, 1);
             Assert.AreEqual(slice3.Width, 1);
             Assert.AreEqual(slice3.Span[0, 0], 5);

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_ReadOnlySpan2D{T}.cs
@@ -22,14 +22,14 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> empty1 = default;
 
             Assert.IsTrue(empty1.IsEmpty);
-            Assert.AreEqual(empty1.Size, 0);
+            Assert.AreEqual(empty1.Length, 0);
             Assert.AreEqual(empty1.Width, 0);
             Assert.AreEqual(empty1.Height, 0);
 
             ReadOnlySpan2D<string> empty2 = ReadOnlySpan2D<string>.Empty;
 
             Assert.IsTrue(empty2.IsEmpty);
-            Assert.AreEqual(empty2.Size, 0);
+            Assert.AreEqual(empty2.Length, 0);
             Assert.AreEqual(empty2.Width, 0);
             Assert.AreEqual(empty2.Height, 0);
         }
@@ -47,7 +47,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = ReadOnlySpan2D<int>.DangerousCreate(span[0], 2, 3, 0);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 0], 1);
@@ -76,7 +76,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(ptr, 2, 3, 0);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 0], 1);
@@ -100,7 +100,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 1, 2, 2, 1);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 4);
+            Assert.AreEqual(span2d.Length, 4);
             Assert.AreEqual(span2d.Width, 2);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 0], 2);
@@ -127,7 +127,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 1], 2);
@@ -149,7 +149,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 0, 1, 2, 2);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 4);
+            Assert.AreEqual(span2d.Length, 4);
             Assert.AreEqual(span2d.Width, 2);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 0], 2);
@@ -177,7 +177,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 1);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 0], 10);
@@ -207,7 +207,7 @@ namespace UnitTests.HighPerformance.Memory
             ReadOnlySpan2D<int> span2d = new ReadOnlySpan2D<int>(array, 1, 0, 1, 2, 2);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 4);
+            Assert.AreEqual(span2d.Length, 4);
             Assert.AreEqual(span2d.Width, 2);
             Assert.AreEqual(span2d.Height, 2);
             Assert.AreEqual(span2d[0, 0], 20);
@@ -405,7 +405,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlySpan2D<int> slice1 = span2d.Slice(1, 1, 2, 1);
 
-            Assert.AreEqual(slice1.Size, 2);
+            Assert.AreEqual(slice1.Length, 2);
             Assert.AreEqual(slice1.Height, 1);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1[0, 0], 5);
@@ -413,7 +413,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlySpan2D<int> slice2 = span2d.Slice(0, 1, 2, 2);
 
-            Assert.AreEqual(slice2.Size, 4);
+            Assert.AreEqual(slice2.Length, 4);
             Assert.AreEqual(slice2.Height, 2);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2[0, 0], 2);
@@ -443,7 +443,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlySpan2D<int> slice1 = span2d.Slice(0, 0, 2, 2);
 
-            Assert.AreEqual(slice1.Size, 4);
+            Assert.AreEqual(slice1.Length, 4);
             Assert.AreEqual(slice1.Height, 2);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1[0, 0], 1);
@@ -451,7 +451,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlySpan2D<int> slice2 = slice1.Slice(1, 0, 2, 1);
 
-            Assert.AreEqual(slice2.Size, 2);
+            Assert.AreEqual(slice2.Length, 2);
             Assert.AreEqual(slice2.Height, 1);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2[0, 0], 4);
@@ -459,7 +459,7 @@ namespace UnitTests.HighPerformance.Memory
 
             ReadOnlySpan2D<int> slice3 = slice2.Slice(0, 1, 1, 1);
 
-            Assert.AreEqual(slice3.Size, 1);
+            Assert.AreEqual(slice3.Length, 1);
             Assert.AreEqual(slice3.Height, 1);
             Assert.AreEqual(slice3.Width, 1);
             Assert.AreEqual(slice3[0, 0], 5);
@@ -512,7 +512,7 @@ namespace UnitTests.HighPerformance.Memory
             Assert.AreEqual(span.Length, 0);
 #else
             Assert.IsTrue(success);
-            Assert.AreEqual(span.Length, span2d.Size);
+            Assert.AreEqual(span.Length, span2d.Length);
 #endif
         }
 

--- a/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Span2D{T}.cs
+++ b/UnitTests/UnitTests.HighPerformance.Shared/Memory/Test_Span2D{T}.cs
@@ -23,28 +23,28 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> empty1 = default;
 
             Assert.IsTrue(empty1.IsEmpty);
-            Assert.AreEqual(empty1.Size, 0);
+            Assert.AreEqual(empty1.Length, 0);
             Assert.AreEqual(empty1.Width, 0);
             Assert.AreEqual(empty1.Height, 0);
 
             Span2D<string> empty2 = Span2D<string>.Empty;
 
             Assert.IsTrue(empty2.IsEmpty);
-            Assert.AreEqual(empty2.Size, 0);
+            Assert.AreEqual(empty2.Length, 0);
             Assert.AreEqual(empty2.Width, 0);
             Assert.AreEqual(empty2.Height, 0);
 
             Span2D<int> empty3 = new int[4, 0];
 
             Assert.IsTrue(empty3.IsEmpty);
-            Assert.AreEqual(empty3.Size, 0);
+            Assert.AreEqual(empty3.Length, 0);
             Assert.AreEqual(empty3.Width, 0);
             Assert.AreEqual(empty3.Height, 4);
 
             Span2D<int> empty4 = new int[0, 7];
 
             Assert.IsTrue(empty4.IsEmpty);
-            Assert.AreEqual(empty4.Size, 0);
+            Assert.AreEqual(empty4.Length, 0);
             Assert.AreEqual(empty4.Width, 7);
             Assert.AreEqual(empty4.Height, 0);
         }
@@ -62,7 +62,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = Span2D<int>.DangerousCreate(ref span[0], 2, 3, 0);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -95,7 +95,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = new Span2D<int>(ptr, 2, 3, 0);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -123,7 +123,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = new Span2D<int>(array, 1, 2, 2, 1);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 4);
+            Assert.AreEqual(span2d.Length, 4);
             Assert.AreEqual(span2d.Width, 2);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -154,7 +154,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = new Span2D<int>(array);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -180,7 +180,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = new Span2D<int>(array, 0, 1, 2, 2);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 4);
+            Assert.AreEqual(span2d.Length, 4);
             Assert.AreEqual(span2d.Width, 2);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -212,7 +212,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = new Span2D<int>(array, 1);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 6);
+            Assert.AreEqual(span2d.Length, 6);
             Assert.AreEqual(span2d.Width, 3);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -246,7 +246,7 @@ namespace UnitTests.HighPerformance.Memory
             Span2D<int> span2d = new Span2D<int>(array, 1, 0, 1, 2, 2);
 
             Assert.IsFalse(span2d.IsEmpty);
-            Assert.AreEqual(span2d.Size, 4);
+            Assert.AreEqual(span2d.Length, 4);
             Assert.AreEqual(span2d.Width, 2);
             Assert.AreEqual(span2d.Height, 2);
 
@@ -535,7 +535,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Span2D<int> slice1 = span2d.Slice(1, 1, 1, 2);
 
-            Assert.AreEqual(slice1.Size, 2);
+            Assert.AreEqual(slice1.Length, 2);
             Assert.AreEqual(slice1.Height, 1);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1[0, 0], 5);
@@ -543,7 +543,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Span2D<int> slice2 = span2d.Slice(0, 1, 2, 2);
 
-            Assert.AreEqual(slice2.Size, 4);
+            Assert.AreEqual(slice2.Length, 4);
             Assert.AreEqual(slice2.Height, 2);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2[0, 0], 2);
@@ -573,7 +573,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Span2D<int> slice1 = span2d.Slice(0, 0, 2, 2);
 
-            Assert.AreEqual(slice1.Size, 4);
+            Assert.AreEqual(slice1.Length, 4);
             Assert.AreEqual(slice1.Height, 2);
             Assert.AreEqual(slice1.Width, 2);
             Assert.AreEqual(slice1[0, 0], 1);
@@ -581,7 +581,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Span2D<int> slice2 = slice1.Slice(1, 0, 1, 2);
 
-            Assert.AreEqual(slice2.Size, 2);
+            Assert.AreEqual(slice2.Length, 2);
             Assert.AreEqual(slice2.Height, 1);
             Assert.AreEqual(slice2.Width, 2);
             Assert.AreEqual(slice2[0, 0], 4);
@@ -589,7 +589,7 @@ namespace UnitTests.HighPerformance.Memory
 
             Span2D<int> slice3 = slice2.Slice(0, 1, 1, 1);
 
-            Assert.AreEqual(slice3.Size, 1);
+            Assert.AreEqual(slice3.Length, 1);
             Assert.AreEqual(slice3.Height, 1);
             Assert.AreEqual(slice3.Width, 1);
             Assert.AreEqual(slice3[0, 0], 5);
@@ -642,7 +642,7 @@ namespace UnitTests.HighPerformance.Memory
             Assert.AreEqual(span.Length, 0);
 #else
             Assert.IsTrue(success);
-            Assert.AreEqual(span.Length, span2d.Size);
+            Assert.AreEqual(span.Length, span2d.Length);
 #endif
         }
 


### PR DESCRIPTION
🆕 C# 9 support to use `nint`
✅ Fixed support for large 2D/3D arrays
✅ `Memory2D<T>.Length` and `Span2D<T>.Length` are now `nint`
✅ Bug fixes in various potentially overflow cases